### PR TITLE
fix: skip AAD-UserWritePassword if SamePassword

### DIFF
--- a/policies/password-reset-not-last-password/TrustFrameworkExtensions.xml
+++ b/policies/password-reset-not-last-password/TrustFrameworkExtensions.xml
@@ -9,7 +9,7 @@
 	</BasePolicy>
 	<BuildingBlocks>
 		<ClaimsSchema>
-			<ClaimType Id="samePassword">
+			<ClaimType Id="SamePassword">
 				<DisplayName>samePassword</DisplayName>
 				<DataType>boolean</DataType>
 				<UserHelpText/>
@@ -94,7 +94,7 @@
 							<Preconditions>
 								<Precondition Type="ClaimEquals" ExecuteActionsIf="true">
 									<Value>SamePassword</Value>
-									<Value>true</Value>
+									<Value>True</Value>
 									<Action>SkipThisValidationTechnicalProfile</Action>
 								</Precondition>
 							</Preconditions>


### PR DESCRIPTION
Compare the claim value with `True` instead of `true`, so the "AAD-UserWritePasswordUsingObjectId" technical profile is skipped as intended. 
This bug was probably not discovered since writing the same password normally does not change anything; but when additional logic is executed in the "WritePassword" profile, the bug's impact becomes visible.