### PR TITLE
Rename claim to match base

### DIFF
--- a/policies/B2C-Token-Includes-AzureAD-BearerToken/Policy/TrustFrameworkExtensions.xml
+++ b/policies/B2C-Token-Includes-AzureAD-BearerToken/Policy/TrustFrameworkExtensions.xml
@@ -113,7 +113,7 @@
             <OutputClaim ClaimTypeReferenceId="givenName" PartnerClaimType="givenName"/>
             <OutputClaim ClaimTypeReferenceId="surname" PartnerClaimType="surname"/>
             <OutputClaim ClaimTypeReferenceId="userPrincipalName" PartnerClaimType="userPrincipalName"/>
-            <OutputClaim ClaimTypeReferenceId="socialIdpUserId" PartnerClaimType="id"/>
+            <OutputClaim ClaimTypeReferenceId="issuerUserId" PartnerClaimType="id"/>
             <OutputClaim ClaimTypeReferenceId="identityProviderAccessToken" PartnerClaimType="{oauth2:access_token}"/>
           </OutputClaims>
           <OutputClaimsTransformations>


### PR DESCRIPTION
According to the comment in the base on line 29, "socialIdpUserId" has been renamed to "issuerUserId". Updating the extension file to match.