### PR TITLE
Added new grant_type metadata item to ROPC TechnicalProfile

### DIFF
--- a/policies/B2C-Token-Includes-AzureAD-BearerToken/Policy/TrustFrameworkBase.xml
+++ b/policies/B2C-Token-Includes-AzureAD-BearerToken/Policy/TrustFrameworkBase.xml
@@ -517,6 +517,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/change-sign-in-name/policy/TrustFrameworkBase.xml
+++ b/policies/change-sign-in-name/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/custom-claims-provider/poicy/TrustFrameworkBase.xml
+++ b/policies/custom-claims-provider/poicy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/custom-email-verifcation/policy/TrustFrameworkBase.xml
+++ b/policies/custom-email-verifcation/policy/TrustFrameworkBase.xml
@@ -517,6 +517,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/disable-inactive-account/TrustFrameworkBase.xml
+++ b/policies/disable-inactive-account/TrustFrameworkBase.xml
@@ -661,6 +661,7 @@
 						<Item Key="response_types">id_token</Item>
 						<Item Key="response_mode">query</Item>
 						<Item Key="scope">email openid</Item>
+						<Item Key="grant_type">password</Item>
 
 						<!-- Policy Engine Clients -->
 						<Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/disable-social-account-from-logon/TrustFrameworkBase.xml
+++ b/policies/disable-social-account-from-logon/TrustFrameworkBase.xml
@@ -498,6 +498,7 @@
 						<Item Key="response_types">id_token</Item>
 						<Item Key="response_mode">query</Item>
 						<Item Key="scope">email openid</Item>
+						<Item Key="grant_type">password</Item>
 
 						<!-- Policy Engine Clients -->
 						<Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/edit-mfa-phone-number/TrustFrameworkBase.xml
+++ b/policies/edit-mfa-phone-number/TrustFrameworkBase.xml
@@ -549,6 +549,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/force-unique-email-across-social-identities/TrustFrameworkBase.xml
+++ b/policies/force-unique-email-across-social-identities/TrustFrameworkBase.xml
@@ -508,6 +508,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/invite_deprecated/TrustFrameworkBase.xml
+++ b/policies/invite_deprecated/TrustFrameworkBase.xml
@@ -550,6 +550,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/lockout/TrustFrameworkBase.xml
+++ b/policies/lockout/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/mfa-add-secondarymfa/TrustFrameworkBase.xml
+++ b/policies/mfa-add-secondarymfa/TrustFrameworkBase.xml
@@ -565,6 +565,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/mfa-unknown-devices/policy/TrustFrameworkBase.xml
+++ b/policies/mfa-unknown-devices/policy/TrustFrameworkBase.xml
@@ -565,6 +565,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/password-reset-not-last-password/TrustFrameworkBase.xml
+++ b/policies/password-reset-not-last-password/TrustFrameworkBase.xml
@@ -703,6 +703,7 @@
 						<Item Key="response_types">id_token</Item>
 						<Item Key="response_mode">query</Item>
 						<Item Key="scope">email openid</Item>
+						<Item Key="grant_type">password</Item>
 
 						<!-- Policy Engine Clients -->
 						<Item Key="UsePolicyInRedirectUri">false</Item>
@@ -1077,6 +1078,7 @@
 						<Item Key="response_types">id_token</Item>
 						<Item Key="response_mode">query</Item>
 						<Item Key="scope">email openid</Item>
+						<Item Key="grant_type">password</Item>
 						<Item Key="UsePolicyInRedirectUri">false</Item>
 						<Item Key="HttpBinding">POST</Item>
 						<Item Key="client_id">a620b2dd-f55f-44bf-b6de-50689224c47f</Item>

--- a/policies/passwordless-email/policy/TrustFrameworkBase.xml
+++ b/policies/passwordless-email/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/relying-party-rbac/policy/TrustFrameworkBase.xml
+++ b/policies/relying-party-rbac/policy/TrustFrameworkBase.xml
@@ -405,6 +405,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/remote-profile/Remote-profile-policies/TrustFrameworkBase.xml
+++ b/policies/remote-profile/Remote-profile-policies/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/remote-profile/Remote-profile-with-hash-policies/TrustFrameworkBase.xml
+++ b/policies/remote-profile/Remote-profile-with-hash-policies/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/sign-in-with-authenticator/policy/TrustFrameworkBase.xml
+++ b/policies/sign-in-with-authenticator/policy/TrustFrameworkBase.xml
@@ -454,6 +454,7 @@ PublicPolicyUri="http://yourtenant.onmicrosoft.com/B2C_1A_TrustFrameworkBase">
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>
             <Item Key="HttpBinding">POST</Item>

--- a/policies/social-idp-force-email/policy/TrustFrameworkBase.xml
+++ b/policies/social-idp-force-email/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/store-three-letters-of-the-password/TrustFrameworkBase.xml
+++ b/policies/store-three-letters-of-the-password/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/policies/username-discovery/TrustFrameworkBase.xml
+++ b/policies/username-discovery/TrustFrameworkBase.xml
@@ -519,7 +519,8 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
-            
+            <Item Key="grant_type">password</Item>
+
             <!-- Demo: configuration -->
             <Item Key="LocalAccountProfile">true</Item>
             <!-- /Demo -->


### PR DESCRIPTION
This is an update to the docs for B2C custom policies adding a `grant_type` metadata item to ROPC-based technical profiles. Adding this metadata item enables Just-in-time migration via ROPC and REST. See [here](https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack/pull/65) for further details.

This is already [in the official B2C docs](https://github.com/MicrosoftDocs/azure-docs/pull/56409) and should be considered the part of the default base policy. 