### PR TITLE
CA Sample - Proper case sensitive ClaimEquals comparison on boolean types

### DIFF
--- a/policies/conditional-access/policy/TrustFrameworkExtensions.xml
+++ b/policies/conditional-access/policy/TrustFrameworkExtensions.xml
@@ -361,7 +361,7 @@
             </Precondition>
             <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
               <Value>CAChallengeIsMfa</Value>
-              <Value>false</Value>
+              <Value>False</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
           </Preconditions>
@@ -394,7 +394,7 @@
             </Precondition>
             <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
               <Value>CAChallengeIsBlock</Value>
-              <Value>true</Value>
+              <Value>True</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
           </Preconditions>


### PR DESCRIPTION
Fix logic bomb in policy precondition on boolean claim types.  After some head scratching, figured out this issue was due to treating boolean in precondition logic as string.  Valid values are case sensitive `True` and `False`.

Most interesting here is how this psuedo behaves as you want it, until you test out all the use cases.  Since `True` =ClaimEquals= "true" just evaluates to a logical `False` - which is 1/2 the scenarios :)

Ref1: https://stackoverflow.com/a/51957101/343347
Ref2: https://stackoverflow.com/a/58821069/343347

See Official Docs PR: https://github.com/MicrosoftDocs/azure-docs/pull/65420