### PR TITLE
 Add estsRequestId Claim and DefaultValue TrustFrameworkExtensionsCA.xml

### DIFF
--- a/policies/conditional-access/policy/TrustFrameworkExtensionsCA.xml
+++ b/policies/conditional-access/policy/TrustFrameworkExtensionsCA.xml
@@ -174,12 +174,17 @@
           </Metadata>
           <OutputClaims>
             <OutputClaim ClaimTypeReferenceId="isFederated" DefaultValue="false" AlwaysUseDefaultValue="true" />
-            <OutputClaim ClaimTypeReferenceId="estsRequestId" />
+            <OutputClaim ClaimTypeReferenceId="estsRequestId" DefaultValue="00000000-0000-0000-0000-000000000000" />
           </OutputClaims>
           <OutputClaimsTransformations>
             <OutputClaimsTransformation ReferenceId="CreatePasswordAuthenticationMethodClaim" />
             <OutputClaimsTransformation ReferenceId="AddToAuthenticationMethodsUsed" />
           </OutputClaimsTransformations>
+        </TechnicalProfile>
+        <TechnicalProfile Id="login-NonInteractive">
+          <OutputClaims>
+            <OutputClaim ClaimTypeReferenceId="estsRequestId" DefaultValue="00000000-0000-0000-0000-000000000000" />
+          </OutputClaims>
         </TechnicalProfile>
       </TechnicalProfiles>
     </ClaimsProvider>


### PR DESCRIPTION
Fix the exception which is caused by missing estsRequestId Claim.
Related issue : https://github.com/azure-ad-b2c/samples/issues/260