### PR TITLE
Update Startup.cs

### DIFF
--- a/policies/custom-mfa-totp/source-code/AADB2C.MFA.TOTP/Startup.cs
+++ b/policies/custom-mfa-totp/source-code/AADB2C.MFA.TOTP/Startup.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AADB2C.MFA.TOTP.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,21 +25,38 @@ namespace AADB2C.MFA.TOTP
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddControllers();
+            services.AddRazorPages();
 
             // Demo: Load the app settings section and bind to AppSettingsModel object graph
             services.Configure<AppSettingsModel>(Configuration.GetSection("AppSettings"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.IsDevelopment())
+            if (env.EnvironmentName == "Development")
             {
                 app.UseDeveloperExceptionPage();
             }
-            app.UseStaticFiles();
-            app.UseMvc();
+            app.UseHttpsRedirection();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapRazorPages();
+
+            });
+            app.UseStaticFiles(new StaticFileOptions()
+            {
+                OnPrepareResponse = ctx => {
+                    ctx.Context.Response.Headers.Append("Access-Control-Allow-Origin", "*");
+                    ctx.Context.Response.Headers.Append("Access-Control-Allow-Headers",
+                      "Origin, X-Requested-With, Content-Type, Accept");
+                },
+
+            });
+            
         }
     }
 }


### PR DESCRIPTION
Configured CORS to avoid  error: "Access to XMLHttpRequest  has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource."
Use of IHostingEnvironment is deprecated in public void Configure