### PR TITLE
FIX / Updated incorrect GenerateOtp metadata key

### DIFF
--- a/policies/custom-email-verifcation-displaycontrol/Sendinblue.md
+++ b/policies/custom-email-verifcation-displaycontrol/Sendinblue.md
@@ -258,7 +258,7 @@ Add the following technical profiles to the `<ClaimsProviders>` element.
         <Item Key="CodeLength">6</Item>
         <Item Key="CharacterSet">0-9</Item>
         <Item Key="ReuseSameCode">true</Item>
-        <Item Key="MaxNumAttempts">5</Item>
+        <Item Key="NumRetryAttempts">5</Item>
       </Metadata>
       <InputClaims>
         <InputClaim ClaimTypeReferenceId="email" PartnerClaimType="identifier" />

--- a/policies/custom-email-verifcation-displaycontrol/policy/Mailjet/DisplayControl_TrustFrameworkExtensions.xml
+++ b/policies/custom-email-verifcation-displaycontrol/policy/Mailjet/DisplayControl_TrustFrameworkExtensions.xml
@@ -214,7 +214,7 @@
             <Item Key="CodeLength">6</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">true</Item>
-            <Item Key="MaxNumAttempts">2</Item>
+            <Item Key="NumRetryAttempts">2</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="email" PartnerClaimType="identifier" />

--- a/policies/custom-email-verifcation-displaycontrol/policy/SendGrid/DisplayControl_TrustFrameworkExtensions.xml
+++ b/policies/custom-email-verifcation-displaycontrol/policy/SendGrid/DisplayControl_TrustFrameworkExtensions.xml
@@ -207,7 +207,7 @@
             <Item Key="CodeLength">6</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">true</Item>
-            <Item Key="MaxNumAttempts">2</Item>
+            <Item Key="NumRetryAttempts">2</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="email" PartnerClaimType="identifier" />

--- a/policies/custom-email-verifcation-displaycontrol/policy/Sendinblue/DisplayControl_TrustFrameworkExtensions.xml
+++ b/policies/custom-email-verifcation-displaycontrol/policy/Sendinblue/DisplayControl_TrustFrameworkExtensions.xml
@@ -206,7 +206,7 @@
             <Item Key="CodeLength">6</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">true</Item>
-            <Item Key="MaxNumAttempts">2</Item>
+            <Item Key="NumRetryAttempts">2</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="email" PartnerClaimType="identifier" />

--- a/policies/custom-sms-displaycontrol/policy/TrustFrameworkExtensionsCustomSMS.xml
+++ b/policies/custom-sms-displaycontrol/policy/TrustFrameworkExtensionsCustomSMS.xml
@@ -316,7 +316,7 @@
             <Item Key="CodeLength">6</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">true</Item>
-            <Item Key="MaxNumAttempts">5</Item>
+            <Item Key="NumRetryAttempts">5</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="strongAuthenticationPhoneNumber" PartnerClaimType="identifier" />

--- a/policies/twilio-mfa-psd2/policy/SignUpSignIn/TrustFrameworkExtensionsPSD2.xml
+++ b/policies/twilio-mfa-psd2/policy/SignUpSignIn/TrustFrameworkExtensionsPSD2.xml
@@ -626,7 +626,7 @@
             <Item Key="CodeLength">4</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">false</Item>
-            <Item Key="MaxNumAttempts">5</Item>
+            <Item Key="NumRetryAttempts">5</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="email" PartnerClaimType="identifier" />

--- a/policies/twilio-mfa-psd2/policy/StepUpPSD2/TrustFrameworkExtensionsPSD2StepUp.xml
+++ b/policies/twilio-mfa-psd2/policy/StepUpPSD2/TrustFrameworkExtensionsPSD2StepUp.xml
@@ -243,7 +243,7 @@
             <Item Key="CodeLength">6</Item>
             <Item Key="CharacterSet">0-9</Item>
             <Item Key="ReuseSameCode">true</Item>
-            <Item Key="MaxNumAttempts">5</Item>
+            <Item Key="NumRetryAttempts">5</Item>
           </Metadata>
           <InputClaims>
             <InputClaim ClaimTypeReferenceId="readOnlystrongAuthenticationPhoneNumber" PartnerClaimType="identifier" />


### PR DESCRIPTION
Fixed `GenerateOtp` metadata from `MaxNumAttempts` to `NumRetryAttempts`

https://docs.microsoft.com/en-us/azure/active-directory-b2c/one-time-password-technical-profile#example