### PR TITLE
Escape minus in sign-up-domain-whitelist

### DIFF
--- a/policies/sign-up-domain-whitelist/policy/Extensions_DomainWhitelist.xml
+++ b/policies/sign-up-domain-whitelist/policy/Extensions_DomainWhitelist.xml
@@ -9,7 +9,7 @@
     <ClaimsSchema>
       <ClaimType Id="email">
         <Restriction>
-          <Pattern RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~-]+@(test[.]com|contoso[.]com|fabrikam[.]com)" HelpText="Please enter a email address from one of the following domains: test.com, contoso.com, or fabrikam.com." />
+          <Pattern RegularExpression="^[a-zA-Z0-9.!#$%&amp;'^_`{}~\-]+@(test[.]com|contoso[.]com|fabrikam[.]com)" HelpText="Please enter a email address from one of the following domains: test.com, contoso.com, or fabrikam.com." />
         </Restriction>
       </ClaimType>
     </ClaimsSchema>


### PR DESCRIPTION
Without doing so the minus was treated as the range operator.