### PR TITLE
Force password reset flow: update readme.md

### DIFF
--- a/policies/force-password-reset/readme.md
+++ b/policies/force-password-reset/readme.md
@@ -1,3 +1,5 @@
-# Force password reset flow 
+# Force password reset flow
 
-This feature is currently only available for User Flows. For more information, see [Set up a force password reset flow in Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/force-password-reset?pivots=b2c-user-flow). 
+As an administrator, you can reset a user's password if the user forgets their password or you would like to force them to reset the password. In this policy sample, you'll learn how to force a password reset in these scenarios.
+
+It's the custom flow described at [Set up a force password reset flow in Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/force-password-reset?pivots=b2c-user-flow).


### PR DESCRIPTION
Hi,

The policy [policies/force-password-reset](https://github.com/azure-ad-b2c/samples/tree/7443808f5de1b7c514c49391d47039d2cbb04b55/policies/force-password-reset) has a strange comment. 

It is said 

> This feature is currently only available for User Flows. For more information, see [Set up a force password reset flow in Azure Active Directory B2C](https://docs.microsoft.com/en-us/azure/active-directory-b2c/force-password-reset?pivots=b2c-user-flow). 

I've tested this into Custom Policy without any problem. It works well.

That's why I guess is better to update this README.md as follow.