### PR TITLE
Fix: Wrong BasePolicy policyId in SignUpSignIn Policy for age gating

### DIFF
--- a/policies/age-gating/policy/SignUpOrSignIn.xml
+++ b/policies/age-gating/policy/SignUpOrSignIn.xml
@@ -10,7 +10,7 @@
 
   <BasePolicy>
     <TenantId>yourtenant.onmicrosoft.com</TenantId>
-    <PolicyId>B2C_1A_TrustFrameworkAgeGatingExtensions</PolicyId>
+    <PolicyId>B2C_1A_Demo_TrustFrameworkAgeGatingExtensions</PolicyId>
   </BasePolicy>
 
   <RelyingParty>


### PR DESCRIPTION
I think that someone forgot to update the base policyId in this file 🙂 