### PR TITLE
Update DisplayControl_TrustFrameworkExtensions.xml

### DIFF
--- a/policies/custom-email-verifcation-displaycontrol/policy/Sendinblue/DisplayControl_TrustFrameworkExtensions.xml
+++ b/policies/custom-email-verifcation-displaycontrol/policy/Sendinblue/DisplayControl_TrustFrameworkExtensions.xml
@@ -58,8 +58,8 @@
           <InputClaim ClaimTypeReferenceId="signature" TransformationClaimType="params.signature" />
         </InputClaims>
         <InputParameters>
-          <!-- TBD <InputParameter Id="template_id" DataType="int" Value="your-sendinblue-templateid"/> -->
-          <InputParameter Id="template_id" DataType="int" Value="1" />
+          <!-- TBD <InputParameter Id="templateId" DataType="int" Value="your-sendinblue-templateid"/> -->
+          <InputParameter Id="templateId" DataType="int" Value="1" />
         </InputParameters>
         <OutputClaims>
           <OutputClaim ClaimTypeReferenceId="emailRequestBody" TransformationClaimType="outputClaim" />


### PR DESCRIPTION
"template_id" is "templateId" in the SendInBlue API: https://developers.sendinblue.com/docs/send-a-transactional-email#1-generate-a-code-snippet-to-quickly-test-your-request. Using "template_id" will return a misleading error message saying that the "sender" parameter is missing, even though "sender" is not required.