### PR TITLE
Fix SelfAsserted ClaimsProvider for progressive profile

### DIFF
--- a/policies/progressive-profile/policy/ProgressiveProfileTrustFrameworkExtensions.xml
+++ b/policies/progressive-profile/policy/ProgressiveProfileTrustFrameworkExtensions.xml
@@ -25,12 +25,25 @@
 
   <ClaimsProviders>
     <ClaimsProvider>
-      <DisplayName>Self Asserted</DisplayName>
+      <DisplayName>Self Asserted Progressive Profiling</DisplayName>
       <TechnicalProfiles>
-        <TechnicalProfile Id="SelfAsserted-ProfileUpdate">
-        <OutputClaims>
-          <OutputClaim ClaimTypeReferenceId="extension_LoyaltyNumber" Required="true"/>
+        <TechnicalProfile Id="SelfAsserted-ProgressiveProfile">
+          <DisplayName>User ID signup</DisplayName>
+          <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.SelfAssertedAttributeProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
+          <Metadata>
+            <Item Key="ContentDefinitionReferenceId">api.selfasserted.profileupdate</Item>
+          </Metadata>
+          <IncludeInSso>false</IncludeInSso>
+          <InputClaims>
+            <InputClaim ClaimTypeReferenceId="userPrincipalName" />
+          </InputClaims>
+          <OutputClaims>
+            <OutputClaim ClaimTypeReferenceId="executed-SelfAsserted-Input" DefaultValue="true" />
+            <OutputClaim ClaimTypeReferenceId="extension_LoyaltyNumber" Required="true"/>
           </OutputClaims>
+          <ValidationTechnicalProfiles>
+            <ValidationTechnicalProfile ReferenceId="AAD-UserWriteProfileUsingObjectId" />
+          </ValidationTechnicalProfiles>
         </TechnicalProfile>
       </TechnicalProfiles>
     </ClaimsProvider>
@@ -102,7 +115,7 @@
             </Precondition>
           </Preconditions>
           <ClaimsExchanges>
-            <ClaimsExchange Id="ProfileUpdateExchange" TechnicalProfileReferenceId="SelfAsserted-ProfileUpdate" />
+            <ClaimsExchange Id="ProfileUpdateExchange" TechnicalProfileReferenceId="SelfAsserted-ProgressiveProfile" />
           </ClaimsExchanges>
         </OrchestrationStep>
         <OrchestrationStep Order="5" Type="SendClaims" CpimIssuerTechnicalProfileReferenceId="JwtIssuer" />


### PR DESCRIPTION
Defined new `Self Asserted Progressive Profiling` ClaimsProvider with `SelfAsserted-ProgressiveProfile` TechnicalProfile

Existing `SelfAsserted-ProfileUpdate` TechnicalProfile extends TrustFrameworkBase where `SelfAsserted-ProfileUpdate` TechnicalProfile is designed to handle profile editing. It captures `givenName` and `surname` provided by user. In result form displayed to the user in progressive profile sample contains custom property `extension_LoyaltyNumber`, but since it extends base TechicalProfile it displays `givenName` and `surname` as well. 

![existing](https://user-images.githubusercontent.com/28896327/199594537-35fd28c8-268c-4346-b54b-431f76549e97.jpg)

I believe the idea of progressive profiling is to display form with single, isolated `extension_LoyaltyNumber` field. After changes form looks like the following and does not allow to edit additional profile information.

![now](https://user-images.githubusercontent.com/28896327/199594573-74c5add6-88b4-40b5-b194-acbe383f2b78.jpg)
