### PR TITLE
Update TrustFrameworkExtensions_TOTP.xml

### DIFF
--- a/policies/totp/policy/TrustFrameworkExtensions_TOTP.xml
+++ b/policies/totp/policy/TrustFrameworkExtensions_TOTP.xml
@@ -44,7 +44,7 @@
       </ClaimType>
 
       <ClaimType Id="QrCodeVerifyInstruction">
-        <DisplayName>Enter the verification code from your authenticator app​.</DisplayName>
+        <DisplayName>Enter the verification code from your authenticator app.</DisplayName>
         <DataType>string</DataType>
         <UserInputType>Paragraph</UserInputType>
       </ClaimType>
@@ -242,7 +242,7 @@
           <LocalizedString ElementType="DisplayControl" ElementId="authenticatorInfoControl" StringId="collapse_text">Still having trouble?</LocalizedString>
 
           <!-- Verification -->
-          <LocalizedString ElementType="ClaimType" ElementId="QrCodeVerifyInstruction" StringId="DisplayName">Enter the verification code from your authenticator app​.</LocalizedString>
+          <LocalizedString ElementType="ClaimType" ElementId="QrCodeVerifyInstruction" StringId="DisplayName">Enter the verification code from your authenticator app.</LocalizedString>
           <LocalizedString ElementType="ClaimType" ElementId="otpCode" StringId="DisplayName">Enter your code.</LocalizedString>
           <!-- <LocalizedString ElementType="UxElement" StringId="button_continue">Verify</LocalizedString> -->
         </LocalizedStrings>


### PR DESCRIPTION
Fix wrong character in message : Enter the verification code from your authenticator app.

That breaks PUT using graph

Using Notepad++ we can see the wrong character after "app" and before dot
![image](https://github.com/azure-ad-b2c/samples/assets/1939153/d8da0edb-933f-4e77-8109-4cf6133861dc)


![image](https://github.com/azure-ad-b2c/samples/assets/1939153/55d07697-8507-411d-960d-8a9f4d7ff26e)
The wrong character in yellow

`2023-07-02T19:08:20.1750614Z StatusCode: 400
2023-07-02T19:08:20.2429304Z Invoke-RestMethod : The remote server returned an error: (400) Bad Request.
2023-07-02T19:08:20.2429795Z At D:\a\r1\a\Drop\Scripts\DeployToB2c.ps1:27 char:17
2023-07-02T19:08:20.2430633Z + ... $response = Invoke-RestMethod -Uri $graphuri -Method Put -Body $polic ...
2023-07-02T19:08:20.2431027Z +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2023-07-02T19:08:20.2431682Z     + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebExc 
2023-07-02T19:08:20.2431977Z    eption
2023-07-02T19:08:20.2432290Z     + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
2023-07-02T19:08:20.2432565Z  
2023-07-02T19:08:20.2547519Z {"error":{"code":"AADB2C","message":"The policy being uploaded is not XML or is not correctly formatted: Name cannot begin with the '.' character, hexadecimal value 0x2E. Line 1, position 13237.","innerError":{"correlationId":"581333fd-8e08-4afe-b925-933554d459da","date":"2023-07-02T19:08:20","request-id":"85150efe-faf9-468a-8e0d-1a02cffd1cb2","client-request-id":"85150efe-faf9-468a-8e0d-1a02cffd1cb2"}}}`



Note: when uploading directly through the portal (Azure AD B2C | Identity Experience Framework) it works normally


