### PR TITLE
Update run.csx

### DIFF
--- a/policies/sign-in-with-apple/azure-function/run.csx
+++ b/policies/sign-in-with-apple/azure-function/run.csx
@@ -1,5 +1,6 @@
 #r "Microsoft.IdentityModel.Tokens"
 #r "Newtonsoft.Json"
+#r "System.Security.Cryptography"
 
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
+
 
 public static async Task<IActionResult> Run(HttpRequest req, ILogger log)
 {


### PR DESCRIPTION
- Adds the missing reference to System.Security.Cryptography assembly
- Removes the duplicated using System.Security.Cryptography; statement that appears in your code