### PR TITLE
signup-signin-with-phone-number: align sample countryList default with Learn mitigation guidance

### DIFF
--- a/policies/signup-signin-with-phone-number/README.md
+++ b/policies/signup-signin-with-phone-number/README.md
@@ -1,5 +1,45 @@
 # A B2C IEF Custom Policy which allows login via Phone Number (OTP)
 
+## ⚠️ Security Warning — SMS Toll Fraud (IRSF)
+
+**Before deploying phone-based authentication in production, implement SMS toll fraud mitigations.**
+
+Azure AD B2C phone-based authentication sends SMS to all supported countries by default without built-in geo-restriction or spending caps. This creates exposure to [International Revenue Share Fraud (IRSF)](https://en.wikipedia.org/wiki/International_revenue_share_fraud), where attackers programmatically trigger SMS OTP deliveries to premium-rate numbers, generating significant costs.
+
+**Recommended mitigations:**
+
+1. **Restrict country codes** — Use the `countryList` allow-list to limit SMS to countries where your users are located. A ready-to-paste snippet is provided below.
+2. **Enable CAPTCHA** — [Add CAPTCHA to sign-up and sign-in](https://learn.microsoft.com/en-us/azure/active-directory-b2c/add-captcha) to prevent automated attacks.
+3. **Conditional Access** — [Block sign-ins based on location](https://learn.microsoft.com/en-us/azure/active-directory-b2c/conditional-access-user-flow).
+4. **Monitor** — Use the [Azure Monitor workbook for phone authentication failures](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa) to detect anomalies.
+
+👉 Full mitigation guide: [Phone-based MFA — Mitigate fraudulent sign-ups for custom policy](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy)
+
+### `countryList` allow-list — now enforced out-of-the-box
+
+This sample now ships with a **Nordic-only allow-list** (`NO`, `SE`, `DK`, `FI`, + `IS` / `FO` / `AX` on the Nordic localizations). All other country codes are blocked at the UX layer — SMS cannot be triggered to them.
+
+The enforcement lives in **two places**, both edited in this PR:
+
+1. **[`policy/TrustFrameworkLocalization.xml`](policy/TrustFrameworkLocalization.xml)** — `countryList` in the `api.phonefactor.sv` and `api.phonefactor.nb` `LocalizedResources`. The previous full world list (~240 countries) has been split into two commented reference tiers right below the active allow-list:
+   - ⚠️ **HIGH-RISK (IRSF / SMS-pumping hotspots)** — must not be uncommented without complementary controls (CAPTCHA, Conditional Access, Azure Monitor anomaly alerts, per-tenant SMS spending cap).
+   - Lower-risk (OECD / EU / major commercial markets) — still review before enabling.
+
+2. **[`policy/phone-signup-signin.xml`](policy/phone-signup-signin.xml)** — a new `BuildingBlocks > Localization` block at the top of the relying party policy adds the same Nordic allow-list for the default English UX path, alongside a prepended `api.phonefactor` `ContentDefinition` that wires in `api.phonefactor.en`.
+
+### Action required before production
+
+Extend the `countryList` JSON in both files with the ISO 3166-1 alpha-2 codes of the countries where your users are. **Do not paste a global list** — each entry opens an SMS egress path that an attacker can pivot to.
+
+```xml
+<!-- policy/phone-signup-signin.xml — extend this JSON -->
+<LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norway","SE":"Sweden","DK":"Denmark","FI":"Finland","IS":"Iceland","FR":"France","US":"United States"}]]></LocalizedString>
+```
+
+Apply the same edit to the `api.phonefactor.sv` and `api.phonefactor.nb` entries in `TrustFrameworkLocalization.xml` with localized country names.
+
+---
+
 ## Updated version notes
 This sample has been updated. The previous version is in the zip file [phone_SUSI_old.zip](policy/phone_SUSI_old.zip) for your conveniance.
 

--- a/policies/signup-signin-with-phone-number/policy/TrustFrameworkLocalization.xml
+++ b/policies/signup-signin-with-phone-number/policy/TrustFrameworkLocalization.xml
@@ -379,9 +379,70 @@
       <LocalizedResources Id="api.phonefactor.sv">
         <LocalizedCollections></LocalizedCollections>
         <LocalizedStrings>
-          <LocalizedString ElementType="UxElement" StringId="countryList">
-            <![CDATA[{"NO":"Norge","SE":"Sverige","DK":"Danmark","FI":"Finland","AF":"Afghanistan","AL":"Albania","DZ":"Algerie","AS":"Amerikansk Samoa","AD":"Andorra","AO":"Angola","AI":"Anguilla","AQ":"Antarktis","AG":"Antigua og Barbuda","AR":"Argentina","AM":"Armenia","AW":"Aruba","AZ":"Aserbajdsjan","AU":"Australia","BS":"Bahamas","BH":"Bahrain","BD":"Bangladesh","BB":"Barbados","BE":"Belgia","BZ":"Belize","BJ":"Benin","BM":"Bermuda","BT":"Bhutan","BO":"Bolivia","BQ":"Bonaire","BA":"Bosnia-Hercegovina","BW":"Botswana","BV":"Bouvetøya","BR":"Brasil","BN":"Brunei","BG":"Bulgaria","BF":"Burkina Faso","BI":"Burundi","CV":"Cabo Verde","CA":"Canada","KY":"Caymanøyene","CL":"Chile","CX":"Christmasøya","CO":"Colombia","CK":"Cookøyene","CR":"Costa Rica","CU":"Cuba","CW":"Curaçao","VI":"De amerikanske jomfruøyene","VG":"De britiske jomfruøyene","AE":"De forente arabiske emirater","TF":"De franske sørterritorier","DO":"Den dominikanske republikk","PS":"Den palestinske selvstyremyndighet","CF":"Den sentralafrikanske republikk","IO":"Det britiske territoriet i Indiahavet","DJ":"Djibouti","DM":"Dominica","EC":"Ecuador","EG":"Egypt","GQ":"Ekvatorial-Guinea","SV":"El Salvador","CI":"Elfenbenskysten (Côte d’Ivoire)","ER":"Eritrea","EE":"Estland","SZ":"Eswatini","ET":"Etiopia","FK":"Falklandsøyene","FJ":"Fiji","PH":"Filippinene","FR":"Frankrike","GF":"Fransk Guyana","PF":"Fransk Polynesia","FO":"Færøyene","GA":"Gabon","GM":"Gambia","GE":"Georgia","GH":"Ghana","GI":"Gibraltar","GD":"Grenada","GL":"Grønland","GP":"Guadeloupe","GU":"Guam","GT":"Guatemala","GG":"Guernsey","GN":"Guinea","GW":"Guinea-Bissau","GY":"Guyana","HT":"Haiti","GR":"Hellas","HN":"Honduras","HK":"Hongkong SAR","BY":"Hviterussland","IN":"India","ID":"Indonesia","IQ":"Irak","IR":"Iran","IE":"Irland","IS":"Island","IL":"Israel","IT":"Italia","JM":"Jamaica","JP":"Japan","YE":"Jemen","JE":"Jersey","JO":"Jordan","KH":"Kambodsja","CM":"Kamerun","KZ":"Kasakhstan","KE":"Kenya","CN":"Kina","KG":"Kirgisistan","KI":"Kiribati","CC":"Kokosøyene","KM":"Komorene","CD":"Kongo","CG":"Kongo-Brazzaville","HR":"Kroatia","KW":"Kuwait","CY":"Kypros","LA":"Laos","LV":"Latvia","LS":"Lesotho","LB":"Libanon","LR":"Liberia","LY":"Libya","LI":"Liechtenstein","LT":"Litauen","LU":"Luxemburg","MO":"Macao SAR","MG":"Madagaskar","MW":"Malawi","MY":"Malaysia","MV":"Maldivene","ML":"Mali","MT":"Malta","IM":"Man","MA":"Marokko","MH":"Marshalløyene","MQ":"Martinique","MR":"Mauritania","MU":"Mauritius","YT":"Mayotte","MX":"Mexico","FM":"Mikronesiaføderasjonen","MD":"Moldova","MC":"Monaco","MN":"Mongolia","ME":"Montenegro","MS":"Montserrat","MZ":"Mosambik","MM":"Myanmar","NA":"Namibia","NR":"Nauru","NL":"Nederland","NP":"Nepal","NZ":"New Zealand","NI":"Nicaragua","NE":"Niger","NG":"Nigeria","NU":"Niue","KP":"Nord-Korea","MK":"Nord-Makedonia","MP":"Nord-Marianene","NF":"Norfolkøya","NC":"Ny-Caledonia","OM":"Oman","PK":"Pakistan","PW":"Palau","PA":"Panama","PG":"Papua Ny-Guinea","PY":"Paraguay","PE":"Peru","PN":"Pitcairn","PL":"Polen","PT":"Portugal","PR":"Puerto Rico","QA":"Qatar","RE":"Réunion","RO":"Romania","RU":"Russland","RW":"Rwanda","KN":"Saint Kitts og Nevis","BL":"Saint-Barthélemy","MF":"Saint-Martin","PM":"Saint-Pierre-et-Miquelon","SB":"Salomonøyene","WS":"Samoa","SM":"San Marino","ST":"São Tomé og Príncipe","SA":"Saudi-Arabia","SN":"Senegal","RS":"Serbia","SC":"Seychellene","SL":"Sierra Leone","SG":"Singapore","SX":"Sint Maarten","SK":"Slovakia","SI":"Slovenia","SO":"Somalia","ES":"Spania","LK":"Sri Lanka","SH":"St. Helena, Ascension, Tristan da Cunha","LC":"St. Lucia","VC":"St. Vincent og Grenadinene","GB":"Storbritannia","SD":"Sudan","SR":"Surinam","SJ":"Svalbard","CH":"Sveits","SY":"Syria","ZA":"Sør-Afrika","GS":"Sør-Georgia og Sør-Sandwichøyene","KR":"Sør-Korea","SS":"Sør-Sudan","TJ":"Tadsjikistan","TW":"Taiwan","TZ":"Tanzania","HM":"Territoriet Heard- og McDonaldøyene","TH":"Thailand","TL":"Timor-Leste","TG":"Togo","TK":"Tokelau","TO":"Tonga","TT":"Trinidad og Tobago","TD":"Tsjad","CZ":"Tsjekkia","TN":"Tunisia","TM":"Turkmenistan","TC":"Turks- og Caicosøyene","TV":"Tuvalu","TR":"Tyrkia","DE":"Tyskland","UG":"Uganda","UA":"Ukraina","HU":"Ungarn","UY":"Uruguay","US":"USA","UM":"USAs ytre øyer","UZ":"Usbekistan","VU":"Vanuatu","VA":"Vatikanstaten","VE":"Venezuela","VN":"Vietnam","WF":"Wallis og Futuna","ZM":"Zambia","ZW":"Zimbabwe","AT":"Østerrike","AX":"Åland"}]]>
-          </LocalizedString>
+          <!-- SMS toll fraud (IRSF) mitigation — countryList is an ALLOW-LIST.
+               Only country codes listed here will be selectable in the MFA phone prompt;
+               all others are blocked at the UX layer.
+          
+               DEFAULT (shipped):  Nordics only — matches this sample's nb/sv localization.
+               Action required:    expand the JSON below with countries where your users are.
+                                   Do NOT paste the full world list — uncomment entries one by one.
+          
+               See: https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy -->
+          <LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norge","SE":"Sverige","DK":"Danmark","FI":"Finland","IS":"Island","FO":"Färöarna","AX":"Åland"}]]></LocalizedString>
+
+          <!-- ============================================================================
+               REFERENCE ONLY — full legacy country list, split into RISK TIERS.
+               Copy entries from the "Lower-risk" tier into the active countryList above
+               as your business expands. Keep HIGH-RISK entries commented unless you have
+               a documented business need AND complementary controls (CAPTCHA, Conditional
+               Access, Azure Monitor anomaly alerts, per-tenant SMS spending cap).
+               ============================================================================
+
+               ⚠️  HIGH-RISK (IRSF / SMS-pumping hotspots) — DO NOT UNCOMMENT WITHOUT REVIEW:
+                   "AF":"Afghanistan", "AL":"Albania", "DZ":"Algerie", "AI":"Anguilla", "AQ":"Antarktis", "AZ":"Aserbajdsjan"
+                   "BD":"Bangladesh", "BJ":"Benin", "BT":"Bhutan", "BV":"Bouvetøya", "BI":"Burundi", "CK":"Cookøyene"
+                   "CU":"Cuba", "TF":"De franske sørterritorier", "CF":"Den sentralafrikanske republikk", "IO":"Det britiske territoriet i Indiahavet", "DJ":"Djibouti", "DM":"Dominica"
+                   "GQ":"Ekvatorial-Guinea", "CI":"Elfenbenskysten (Côte d’Ivoire)", "ER":"Eritrea", "ET":"Etiopia", "FK":"Falklandsøyene", "GA":"Gabon"
+                   "GM":"Gambia", "GH":"Ghana", "GD":"Grenada", "GN":"Guinea", "GW":"Guinea-Bissau", "IQ":"Irak"
+                   "IR":"Iran", "YE":"Jemen", "KH":"Kambodsja", "CM":"Kamerun", "KZ":"Kasakhstan", "KE":"Kenya"
+                   "KG":"Kirgisistan", "KI":"Kiribati", "CD":"Kongo", "CG":"Kongo-Brazzaville", "LA":"Laos", "LB":"Libanon"
+                   "LR":"Liberia", "LY":"Libya", "MG":"Madagaskar", "MW":"Malawi", "MV":"Maldivene", "ML":"Mali"
+                   "MA":"Marokko", "MH":"Marshalløyene", "MR":"Mauritania", "FM":"Mikronesiaføderasjonen", "MS":"Montserrat", "MZ":"Mosambik"
+                   "MM":"Myanmar", "NR":"Nauru", "NP":"Nepal", "NE":"Niger", "NG":"Nigeria", "NU":"Niue"
+                   "KP":"Nord-Korea", "PK":"Pakistan", "PW":"Palau", "RU":"Russland", "RW":"Rwanda", "KN":"Saint Kitts og Nevis"
+                   "BL":"Saint-Barthélemy", "PM":"Saint-Pierre-et-Miquelon", "SN":"Senegal", "SL":"Sierra Leone", "SO":"Somalia", "LK":"Sri Lanka"
+                   "SH":"St. Helena, Ascension, Tristan da Cunha", "LC":"St. Lucia", "VC":"St. Vincent og Grenadinene", "SD":"Sudan", "SJ":"Svalbard", "SY":"Syria"
+                   "GS":"Sør-Georgia og Sør-Sandwichøyene", "SS":"Sør-Sudan", "TJ":"Tadsjikistan", "TZ":"Tanzania", "HM":"Territoriet Heard- og McDonaldøyene", "TG":"Togo"
+                   "TK":"Tokelau", "TO":"Tonga", "TD":"Tsjad", "TN":"Tunisia", "TM":"Turkmenistan", "TC":"Turks- og Caicosøyene"
+                   "TV":"Tuvalu", "UG":"Uganda", "UA":"Ukraina", "UZ":"Usbekistan", "VN":"Vietnam", "WF":"Wallis og Futuna"
+                   "ZM":"Zambia", "ZW":"Zimbabwe"
+
+               Lower-risk (OECD / EU / major commercial markets — still review before enabling):
+                   "AS":"Amerikansk Samoa", "AD":"Andorra", "AO":"Angola", "AG":"Antigua og Barbuda", "AR":"Argentina", "AM":"Armenia"
+                   "AW":"Aruba", "AU":"Australia", "BS":"Bahamas", "BH":"Bahrain", "BB":"Barbados", "BE":"Belgia"
+                   "BZ":"Belize", "BM":"Bermuda", "BO":"Bolivia", "BQ":"Bonaire", "BA":"Bosnia-Hercegovina", "BW":"Botswana"
+                   "BR":"Brasil", "BN":"Brunei", "BG":"Bulgaria", "BF":"Burkina Faso", "CV":"Cabo Verde", "CA":"Canada"
+                   "KY":"Caymanøyene", "CL":"Chile", "CX":"Christmasøya", "CO":"Colombia", "CR":"Costa Rica", "CW":"Curaçao"
+                   "VI":"De amerikanske jomfruøyene", "VG":"De britiske jomfruøyene", "AE":"De forente arabiske emirater", "DO":"Den dominikanske republikk", "PS":"Den palestinske selvstyremyndighet", "EC":"Ecuador"
+                   "EG":"Egypt", "SV":"El Salvador", "EE":"Estland", "SZ":"Eswatini", "FJ":"Fiji", "PH":"Filippinene"
+                   "FR":"Frankrike", "GF":"Fransk Guyana", "PF":"Fransk Polynesia", "GE":"Georgia", "GI":"Gibraltar", "GL":"Grønland"
+                   "GP":"Guadeloupe", "GU":"Guam", "GT":"Guatemala", "GG":"Guernsey", "GY":"Guyana", "HT":"Haiti"
+                   "GR":"Hellas", "HN":"Honduras", "HK":"Hongkong SAR", "BY":"Hviterussland", "IN":"India", "ID":"Indonesia"
+                   "IE":"Irland", "IL":"Israel", "IT":"Italia", "JM":"Jamaica", "JP":"Japan", "JE":"Jersey"
+                   "JO":"Jordan", "CN":"Kina", "CC":"Kokosøyene", "KM":"Komorene", "HR":"Kroatia", "KW":"Kuwait"
+                   "CY":"Kypros", "LV":"Latvia", "LS":"Lesotho", "LI":"Liechtenstein", "LT":"Litauen", "LU":"Luxemburg"
+                   "MO":"Macao SAR", "MY":"Malaysia", "MT":"Malta", "IM":"Man", "MQ":"Martinique", "MU":"Mauritius"
+                   "YT":"Mayotte", "MX":"Mexico", "MD":"Moldova", "MC":"Monaco", "MN":"Mongolia", "ME":"Montenegro"
+                   "NA":"Namibia", "NL":"Nederland", "NZ":"New Zealand", "NI":"Nicaragua", "MK":"Nord-Makedonia", "MP":"Nord-Marianene"
+                   "NF":"Norfolkøya", "NC":"Ny-Caledonia", "OM":"Oman", "PA":"Panama", "PG":"Papua Ny-Guinea", "PY":"Paraguay"
+                   "PE":"Peru", "PN":"Pitcairn", "PL":"Polen", "PT":"Portugal", "PR":"Puerto Rico", "QA":"Qatar"
+                   "RE":"Réunion", "RO":"Romania", "MF":"Saint-Martin", "SB":"Salomonøyene", "WS":"Samoa", "SM":"San Marino"
+                   "ST":"São Tomé og Príncipe", "SA":"Saudi-Arabia", "RS":"Serbia", "SC":"Seychellene", "SG":"Singapore", "SX":"Sint Maarten"
+                   "SK":"Slovakia", "SI":"Slovenia", "ES":"Spania", "GB":"Storbritannia", "SR":"Surinam", "CH":"Sveits"
+                   "ZA":"Sør-Afrika", "KR":"Sør-Korea", "TW":"Taiwan", "TH":"Thailand", "TL":"Timor-Leste", "TT":"Trinidad og Tobago"
+                   "CZ":"Tsjekkia", "TR":"Tyrkia", "DE":"Tyskland", "HU":"Ungarn", "UY":"Uruguay", "US":"USA"
+                   "UM":"USAs ytre øyer", "VU":"Vanuatu", "VA":"Vatikanstaten", "VE":"Venezuela", "AT":"Østerrike"
+           -->
           <!-- <LocalizedString ElementType="UxElement" StringId="button_continue">Fortsätt</LocalizedString> -->
           <LocalizedString ElementType="UxElement" StringId="button_cancel">Avbryt</LocalizedString>
         </LocalizedStrings>
@@ -853,9 +914,70 @@
       <LocalizedResources Id="api.phonefactor.nb">
         <LocalizedCollections></LocalizedCollections>
         <LocalizedStrings>
-          <LocalizedString ElementType="UxElement" StringId="countryList">
-            <![CDATA[{"NO":"Norge","SE":"Sverige","DK":"Danmark","FI":"Finland","AF":"Afghanistan","AL":"Albania","DZ":"Algerie","AS":"Amerikansk Samoa","AD":"Andorra","AO":"Angola","AI":"Anguilla","AQ":"Antarktis","AG":"Antigua og Barbuda","AR":"Argentina","AM":"Armenia","AW":"Aruba","AZ":"Aserbajdsjan","AU":"Australia","BS":"Bahamas","BH":"Bahrain","BD":"Bangladesh","BB":"Barbados","BE":"Belgia","BZ":"Belize","BJ":"Benin","BM":"Bermuda","BT":"Bhutan","BO":"Bolivia","BQ":"Bonaire","BA":"Bosnia-Hercegovina","BW":"Botswana","BV":"Bouvetøya","BR":"Brasil","BN":"Brunei","BG":"Bulgaria","BF":"Burkina Faso","BI":"Burundi","CV":"Cabo Verde","CA":"Canada","KY":"Caymanøyene","CL":"Chile","CX":"Christmasøya","CO":"Colombia","CK":"Cookøyene","CR":"Costa Rica","CU":"Cuba","CW":"Curaçao","VI":"De amerikanske jomfruøyene","VG":"De britiske jomfruøyene","AE":"De forente arabiske emirater","TF":"De franske sørterritorier","DO":"Den dominikanske republikk","PS":"Den palestinske selvstyremyndighet","CF":"Den sentralafrikanske republikk","IO":"Det britiske territoriet i Indiahavet","DJ":"Djibouti","DM":"Dominica","EC":"Ecuador","EG":"Egypt","GQ":"Ekvatorial-Guinea","SV":"El Salvador","CI":"Elfenbenskysten (Côte d’Ivoire)","ER":"Eritrea","EE":"Estland","SZ":"Eswatini","ET":"Etiopia","FK":"Falklandsøyene","FJ":"Fiji","PH":"Filippinene","FR":"Frankrike","GF":"Fransk Guyana","PF":"Fransk Polynesia","FO":"Færøyene","GA":"Gabon","GM":"Gambia","GE":"Georgia","GH":"Ghana","GI":"Gibraltar","GD":"Grenada","GL":"Grønland","GP":"Guadeloupe","GU":"Guam","GT":"Guatemala","GG":"Guernsey","GN":"Guinea","GW":"Guinea-Bissau","GY":"Guyana","HT":"Haiti","GR":"Hellas","HN":"Honduras","HK":"Hongkong SAR","BY":"Hviterussland","IN":"India","ID":"Indonesia","IQ":"Irak","IR":"Iran","IE":"Irland","IS":"Island","IL":"Israel","IT":"Italia","JM":"Jamaica","JP":"Japan","YE":"Jemen","JE":"Jersey","JO":"Jordan","KH":"Kambodsja","CM":"Kamerun","KZ":"Kasakhstan","KE":"Kenya","CN":"Kina","KG":"Kirgisistan","KI":"Kiribati","CC":"Kokosøyene","KM":"Komorene","CD":"Kongo","CG":"Kongo-Brazzaville","HR":"Kroatia","KW":"Kuwait","CY":"Kypros","LA":"Laos","LV":"Latvia","LS":"Lesotho","LB":"Libanon","LR":"Liberia","LY":"Libya","LI":"Liechtenstein","LT":"Litauen","LU":"Luxemburg","MO":"Macao SAR","MG":"Madagaskar","MW":"Malawi","MY":"Malaysia","MV":"Maldivene","ML":"Mali","MT":"Malta","IM":"Man","MA":"Marokko","MH":"Marshalløyene","MQ":"Martinique","MR":"Mauritania","MU":"Mauritius","YT":"Mayotte","MX":"Mexico","FM":"Mikronesiaføderasjonen","MD":"Moldova","MC":"Monaco","MN":"Mongolia","ME":"Montenegro","MS":"Montserrat","MZ":"Mosambik","MM":"Myanmar","NA":"Namibia","NR":"Nauru","NL":"Nederland","NP":"Nepal","NZ":"New Zealand","NI":"Nicaragua","NE":"Niger","NG":"Nigeria","NU":"Niue","KP":"Nord-Korea","MK":"Nord-Makedonia","MP":"Nord-Marianene","NF":"Norfolkøya","NC":"Ny-Caledonia","OM":"Oman","PK":"Pakistan","PW":"Palau","PA":"Panama","PG":"Papua Ny-Guinea","PY":"Paraguay","PE":"Peru","PN":"Pitcairn","PL":"Polen","PT":"Portugal","PR":"Puerto Rico","QA":"Qatar","RE":"Réunion","RO":"Romania","RU":"Russland","RW":"Rwanda","KN":"Saint Kitts og Nevis","BL":"Saint-Barthélemy","MF":"Saint-Martin","PM":"Saint-Pierre-et-Miquelon","SB":"Salomonøyene","WS":"Samoa","SM":"San Marino","ST":"São Tomé og Príncipe","SA":"Saudi-Arabia","SN":"Senegal","RS":"Serbia","SC":"Seychellene","SL":"Sierra Leone","SG":"Singapore","SX":"Sint Maarten","SK":"Slovakia","SI":"Slovenia","SO":"Somalia","ES":"Spania","LK":"Sri Lanka","SH":"St. Helena, Ascension, Tristan da Cunha","LC":"St. Lucia","VC":"St. Vincent og Grenadinene","GB":"Storbritannia","SD":"Sudan","SR":"Surinam","SJ":"Svalbard","CH":"Sveits","SY":"Syria","ZA":"Sør-Afrika","GS":"Sør-Georgia og Sør-Sandwichøyene","KR":"Sør-Korea","SS":"Sør-Sudan","TJ":"Tadsjikistan","TW":"Taiwan","TZ":"Tanzania","HM":"Territoriet Heard- og McDonaldøyene","TH":"Thailand","TL":"Timor-Leste","TG":"Togo","TK":"Tokelau","TO":"Tonga","TT":"Trinidad og Tobago","TD":"Tsjad","CZ":"Tsjekkia","TN":"Tunisia","TM":"Turkmenistan","TC":"Turks- og Caicosøyene","TV":"Tuvalu","TR":"Tyrkia","DE":"Tyskland","UG":"Uganda","UA":"Ukraina","HU":"Ungarn","UY":"Uruguay","US":"USA","UM":"USAs ytre øyer","UZ":"Usbekistan","VU":"Vanuatu","VA":"Vatikanstaten","VE":"Venezuela","VN":"Vietnam","WF":"Wallis og Futuna","ZM":"Zambia","ZW":"Zimbabwe","AT":"Østerrike","AX":"Åland"}]]>
-          </LocalizedString>
+          <!-- SMS toll fraud (IRSF) mitigation — countryList is an ALLOW-LIST.
+               Only country codes listed here will be selectable in the MFA phone prompt;
+               all others are blocked at the UX layer.
+          
+               DEFAULT (shipped):  Nordics only — matches this sample's nb/sv localization.
+               Action required:    expand the JSON below with countries where your users are.
+                                   Do NOT paste the full world list — uncomment entries one by one.
+          
+               See: https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy -->
+          <LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norge","SE":"Sverige","DK":"Danmark","FI":"Finland","IS":"Island","FO":"Færøyene","AX":"Åland"}]]></LocalizedString>
+
+          <!-- ============================================================================
+               REFERENCE ONLY — full legacy country list, split into RISK TIERS.
+               Copy entries from the "Lower-risk" tier into the active countryList above
+               as your business expands. Keep HIGH-RISK entries commented unless you have
+               a documented business need AND complementary controls (CAPTCHA, Conditional
+               Access, Azure Monitor anomaly alerts, per-tenant SMS spending cap).
+               ============================================================================
+
+               ⚠️  HIGH-RISK (IRSF / SMS-pumping hotspots) — DO NOT UNCOMMENT WITHOUT REVIEW:
+                   "AF":"Afghanistan", "AL":"Albania", "DZ":"Algerie", "AI":"Anguilla", "AQ":"Antarktis", "AZ":"Aserbajdsjan"
+                   "BD":"Bangladesh", "BJ":"Benin", "BT":"Bhutan", "BV":"Bouvetøya", "BI":"Burundi", "CK":"Cookøyene"
+                   "CU":"Cuba", "TF":"De franske sørterritorier", "CF":"Den sentralafrikanske republikk", "IO":"Det britiske territoriet i Indiahavet", "DJ":"Djibouti", "DM":"Dominica"
+                   "GQ":"Ekvatorial-Guinea", "CI":"Elfenbenskysten (Côte d’Ivoire)", "ER":"Eritrea", "ET":"Etiopia", "FK":"Falklandsøyene", "GA":"Gabon"
+                   "GM":"Gambia", "GH":"Ghana", "GD":"Grenada", "GN":"Guinea", "GW":"Guinea-Bissau", "IQ":"Irak"
+                   "IR":"Iran", "YE":"Jemen", "KH":"Kambodsja", "CM":"Kamerun", "KZ":"Kasakhstan", "KE":"Kenya"
+                   "KG":"Kirgisistan", "KI":"Kiribati", "CD":"Kongo", "CG":"Kongo-Brazzaville", "LA":"Laos", "LB":"Libanon"
+                   "LR":"Liberia", "LY":"Libya", "MG":"Madagaskar", "MW":"Malawi", "MV":"Maldivene", "ML":"Mali"
+                   "MA":"Marokko", "MH":"Marshalløyene", "MR":"Mauritania", "FM":"Mikronesiaføderasjonen", "MS":"Montserrat", "MZ":"Mosambik"
+                   "MM":"Myanmar", "NR":"Nauru", "NP":"Nepal", "NE":"Niger", "NG":"Nigeria", "NU":"Niue"
+                   "KP":"Nord-Korea", "PK":"Pakistan", "PW":"Palau", "RU":"Russland", "RW":"Rwanda", "KN":"Saint Kitts og Nevis"
+                   "BL":"Saint-Barthélemy", "PM":"Saint-Pierre-et-Miquelon", "SN":"Senegal", "SL":"Sierra Leone", "SO":"Somalia", "LK":"Sri Lanka"
+                   "SH":"St. Helena, Ascension, Tristan da Cunha", "LC":"St. Lucia", "VC":"St. Vincent og Grenadinene", "SD":"Sudan", "SJ":"Svalbard", "SY":"Syria"
+                   "GS":"Sør-Georgia og Sør-Sandwichøyene", "SS":"Sør-Sudan", "TJ":"Tadsjikistan", "TZ":"Tanzania", "HM":"Territoriet Heard- og McDonaldøyene", "TG":"Togo"
+                   "TK":"Tokelau", "TO":"Tonga", "TD":"Tsjad", "TN":"Tunisia", "TM":"Turkmenistan", "TC":"Turks- og Caicosøyene"
+                   "TV":"Tuvalu", "UG":"Uganda", "UA":"Ukraina", "UZ":"Usbekistan", "VN":"Vietnam", "WF":"Wallis og Futuna"
+                   "ZM":"Zambia", "ZW":"Zimbabwe"
+
+               Lower-risk (OECD / EU / major commercial markets — still review before enabling):
+                   "AS":"Amerikansk Samoa", "AD":"Andorra", "AO":"Angola", "AG":"Antigua og Barbuda", "AR":"Argentina", "AM":"Armenia"
+                   "AW":"Aruba", "AU":"Australia", "BS":"Bahamas", "BH":"Bahrain", "BB":"Barbados", "BE":"Belgia"
+                   "BZ":"Belize", "BM":"Bermuda", "BO":"Bolivia", "BQ":"Bonaire", "BA":"Bosnia-Hercegovina", "BW":"Botswana"
+                   "BR":"Brasil", "BN":"Brunei", "BG":"Bulgaria", "BF":"Burkina Faso", "CV":"Cabo Verde", "CA":"Canada"
+                   "KY":"Caymanøyene", "CL":"Chile", "CX":"Christmasøya", "CO":"Colombia", "CR":"Costa Rica", "CW":"Curaçao"
+                   "VI":"De amerikanske jomfruøyene", "VG":"De britiske jomfruøyene", "AE":"De forente arabiske emirater", "DO":"Den dominikanske republikk", "PS":"Den palestinske selvstyremyndighet", "EC":"Ecuador"
+                   "EG":"Egypt", "SV":"El Salvador", "EE":"Estland", "SZ":"Eswatini", "FJ":"Fiji", "PH":"Filippinene"
+                   "FR":"Frankrike", "GF":"Fransk Guyana", "PF":"Fransk Polynesia", "GE":"Georgia", "GI":"Gibraltar", "GL":"Grønland"
+                   "GP":"Guadeloupe", "GU":"Guam", "GT":"Guatemala", "GG":"Guernsey", "GY":"Guyana", "HT":"Haiti"
+                   "GR":"Hellas", "HN":"Honduras", "HK":"Hongkong SAR", "BY":"Hviterussland", "IN":"India", "ID":"Indonesia"
+                   "IE":"Irland", "IL":"Israel", "IT":"Italia", "JM":"Jamaica", "JP":"Japan", "JE":"Jersey"
+                   "JO":"Jordan", "CN":"Kina", "CC":"Kokosøyene", "KM":"Komorene", "HR":"Kroatia", "KW":"Kuwait"
+                   "CY":"Kypros", "LV":"Latvia", "LS":"Lesotho", "LI":"Liechtenstein", "LT":"Litauen", "LU":"Luxemburg"
+                   "MO":"Macao SAR", "MY":"Malaysia", "MT":"Malta", "IM":"Man", "MQ":"Martinique", "MU":"Mauritius"
+                   "YT":"Mayotte", "MX":"Mexico", "MD":"Moldova", "MC":"Monaco", "MN":"Mongolia", "ME":"Montenegro"
+                   "NA":"Namibia", "NL":"Nederland", "NZ":"New Zealand", "NI":"Nicaragua", "MK":"Nord-Makedonia", "MP":"Nord-Marianene"
+                   "NF":"Norfolkøya", "NC":"Ny-Caledonia", "OM":"Oman", "PA":"Panama", "PG":"Papua Ny-Guinea", "PY":"Paraguay"
+                   "PE":"Peru", "PN":"Pitcairn", "PL":"Polen", "PT":"Portugal", "PR":"Puerto Rico", "QA":"Qatar"
+                   "RE":"Réunion", "RO":"Romania", "MF":"Saint-Martin", "SB":"Salomonøyene", "WS":"Samoa", "SM":"San Marino"
+                   "ST":"São Tomé og Príncipe", "SA":"Saudi-Arabia", "RS":"Serbia", "SC":"Seychellene", "SG":"Singapore", "SX":"Sint Maarten"
+                   "SK":"Slovakia", "SI":"Slovenia", "ES":"Spania", "GB":"Storbritannia", "SR":"Surinam", "CH":"Sveits"
+                   "ZA":"Sør-Afrika", "KR":"Sør-Korea", "TW":"Taiwan", "TH":"Thailand", "TL":"Timor-Leste", "TT":"Trinidad og Tobago"
+                   "CZ":"Tsjekkia", "TR":"Tyrkia", "DE":"Tyskland", "HU":"Ungarn", "UY":"Uruguay", "US":"USA"
+                   "UM":"USAs ytre øyer", "VU":"Vanuatu", "VA":"Vatikanstaten", "VE":"Venezuela", "AT":"Østerrike"
+           -->
           <!-- <LocalizedString ElementType="UxElement" StringId="button_continue">Opprett</LocalizedString> -->
           <LocalizedString ElementType="UxElement" StringId="button_cancel">Avbryt</LocalizedString>
         </LocalizedStrings>

--- a/policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml
+++ b/policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml
@@ -19,6 +19,41 @@
 
   <BuildingBlocks>
 
+    <!-- SMS toll fraud (IRSF) mitigation — operational countryList allow-list override
+         for the default (English) UX path. The existing Norwegian/Swedish localizations
+         already ship with a Nordic-only allow-list in TrustFrameworkLocalization.xml.
+         This block makes the English path equally restricted out-of-the-box.
+
+         Action required: extend the "countryList" JSON with the ISO 3166-1 alpha-2 codes
+         of countries where your users are. Do NOT paste a global list — each entry
+         opens an SMS egress path that attackers can pivot to.
+
+         See: https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy -->
+    <ContentDefinitions>
+      <ContentDefinition Id="api.phonefactor">
+        <LoadUri>~/tenant/templates/AzureBlue/multifactor-1.0.0.cshtml</LoadUri>
+        <DataUri>urn:com:microsoft:aad:b2c:elements:contract:multifactor:1.2.20</DataUri>
+        <Metadata>
+          <Item Key="TemplateId">azureBlue</Item>
+        </Metadata>
+        <LocalizedResourcesReferences MergeBehavior="Prepend">
+          <LocalizedResourcesReference Language="en" LocalizedResourcesReferenceId="api.phonefactor.en" />
+        </LocalizedResourcesReferences>
+      </ContentDefinition>
+    </ContentDefinitions>
+
+    <Localization Enabled="true">
+      <SupportedLanguages DefaultLanguage="en" MergeBehavior="Append">
+        <SupportedLanguage>en</SupportedLanguage>
+      </SupportedLanguages>
+      <LocalizedResources Id="api.phonefactor.en">
+        <LocalizedStrings>
+          <!-- ALLOW-LIST — extend with the countries where your users are. -->
+          <LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norway","SE":"Sweden","DK":"Denmark","FI":"Finland","IS":"Iceland"}]]></LocalizedString>
+        </LocalizedStrings>
+      </LocalizedResources>
+    </Localization>
+
     <ClaimsSchema>
       <ClaimType Id="signInNames.phoneNumber">
         <DisplayName>+4XXXXXXXX</DisplayName>

--- a/policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml
+++ b/policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml
@@ -49,7 +49,7 @@
       <LocalizedResources Id="api.phonefactor.en">
         <LocalizedStrings>
           <!-- ALLOW-LIST — extend with the countries where your users are. -->
-          <LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norway","SE":"Sweden","DK":"Denmark","FI":"Finland","IS":"Iceland"}]]></LocalizedString>
+          <LocalizedString ElementType="UxElement" StringId="countryList"><![CDATA[{"NO":"Norway","SE":"Sweden","DK":"Denmark","FI":"Finland","IS":"Iceland","FO":"Faroe Islands","AX":"Åland Islands"}]]></LocalizedString>
         </LocalizedStrings>
       </LocalizedResources>
     </Localization>

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,10 @@
 
 # Azure Active Directory B2C: Custom CIAM User Journeys 
 
+> ## ⚠️ Security Notice — SMS Toll Fraud (IRSF)
+>
+> Samples that use **phone-based authentication** (SMS OTP, voice call) carry financial risk if deployed without fraud mitigations. The [`signup-signin-with-phone-number`](policies/signup-signin-with-phone-number/#️-security-warning--sms-toll-fraud-irsf) sample has a dedicated security section with a ready-to-paste `countryList` allow-list snippet (the recommended first mitigation), and the [full mitigation guide](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy) on Microsoft Learn.
+
 In this repo, you will find samples for several enhanced Azure AD B2C Custom CIAM User Journeys.
 
 ## Getting started
@@ -109,7 +113,7 @@ Samples are available for the following categories
 |Sample name   |Description   |Quick deploy|
 |---|---|---|
 |[Password-less sign-in with email verification](policies/passwordless-email)|Password-less authentication is a type of authentication where user doesn't need to sign-in with their password. This is commonly used in B2C scenarios where users use your application infrequently and tend to forget their password. This sample policy demonstrates how to allow user to sign-in, simply by providing and verifying the sign-in email address using OTP code (one time password).|[Go](https://b2ciefsetupapp.azurewebsites.net/Home/Experimental?sampleFolderName=passwordless-email)|
-|[Login with Phone Number](policies/signup-signin-with-phone-number)|An example set of policies for password-less login via Phone Number (SMS or Phone Call).|[Go](https://b2ciefsetupapp.azurewebsites.net/Home/Experimental?sampleFolderName=signup-signin-with-phone-number)|
+|[Login with Phone Number](policies/signup-signin-with-phone-number)|An example set of policies for password-less login via Phone Number (SMS or Phone Call). **Includes SMS toll fraud (IRSF) mitigation guidance — `countryList` allow-list snippet in the sample README.**|[Go](https://b2ciefsetupapp.azurewebsites.net/Home/Experimental?sampleFolderName=signup-signin-with-phone-number)|
 
 
 ## Multi factor


### PR DESCRIPTION
## Summary

Aligns the `signup-signin-with-phone-number` custom policy sample with the existing Microsoft Learn mitigation guidance for SMS toll fraud (IRSF), by shipping a restrictive-by-default `countryList` in the sample itself and cross-linking [`phone-based-mfa.md`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy).

The sample now ships a Nordic-only allow-list (`NO, SE, DK, FI, IS, FO, AX`) on all three locale paths (`en` / `nb` / `sv`). The previous world-wide list is preserved as XML comments, split into two tiers (HIGH-RISK IRSF hotspots / Lower-risk OECD/EU) so consumers widen the allow-list by uncommenting the tier they accept.

**Tenants outside the listed countries must edit `countryList` before first deployment** — this is called out at the top of the sample README and inline in the XML.

## Problem

Two Microsoft artifacts cover phone-based authentication on Azure AD B2C and complement each other:

- The sample [`policies/signup-signin-with-phone-number/`](policies/signup-signin-with-phone-number/) — one of the phone-based auth samples developers reach when implementing phone-based authentication.
- The mitigation guide [`phone-based-mfa.md`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy) on Microsoft Learn — contains the existing mitigation guidance (`countryList`, CAPTCHA, Conditional Access, Azure Monitor workbook) against fraudulent phone-based MFA sign-ups.

There was no in-repo reference from the sample to the guide, and the sample shipped with no allow-list at all — so a developer uploading the policy as-is was open to IRSF by default. This PR aligns the sample's out-of-box behavior with the Learn guidance, preserves the world list as commented tiers for opt-in widening, and cross-links the guide from the sample README.

## Changes

| # | File | Change |
|---|---|---|
| 1 | [`policies/signup-signin-with-phone-number/policy/TrustFrameworkLocalization.xml`](policies/signup-signin-with-phone-number/policy/TrustFrameworkLocalization.xml) | **Sample default configuration change.** `countryList` `LocalizedString` in both `api.phonefactor.sv` and `api.phonefactor.nb` restricted to Nordic ISO 3166-1 alpha-2 codes (`NO, SE, DK, FI, IS, FO, AX`). Original world list preserved as XML comments, split into two risk tiers: **HIGH-RISK** (IRSF / SMS-pumping hotspots — must not be re-enabled without complementary controls: CAPTCHA, Conditional Access, Azure Monitor anomaly alerts, per-tenant SMS spending cap) and **Lower-risk** (OECD / EU / major commercial markets, still to be reviewed before enabling). Consumers opt into a wider list by uncommenting the tier they accept. |
| 2 | [`policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml`](policies/signup-signin-with-phone-number/policy/phone-signup-signin.xml) | Wires the allow-list on the default English UX path: new `BuildingBlocks > Localization` block with the same Nordic `countryList` (`NO, SE, DK, FI, IS, FO, AX`), and an RP-level `api.phonefactor` `ContentDefinition` override (`LocalizedResourcesReferences MergeBehavior="Prepend"`) so `api.phonefactor.en` is actually applied on the phone-entry page. |
| 3 | [`policies/signup-signin-with-phone-number/README.md`](policies/signup-signin-with-phone-number/README.md) | Security section at the top: link to [`phone-based-mfa.md`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy), documents the Nordic default shipped in the XML, points at the two modified files, and documents the action required before production (extending the allow-list with ISO 3166-1 alpha-2 codes of the countries where users actually are). |
| 4 | [`readme.md`](readme.md) | Security notice above the samples table, and a mitigation note on the existing phone-based sample row. |

## Sources

| Recommendation | Source |
|---|---|
| Restrict `countryList` to an allow-list | [`phone-based-mfa.md` § custom policy](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-custom-policy) and [§ user flow](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa#mitigate-fraudulent-sign-ups-for-user-flow) |
| Add CAPTCHA to sign-up and sign-in | [`add-captcha.md`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/add-captcha) |
| Apply Conditional Access by location (sign-in flows; does not cover sign-up — per Learn) | [`conditional-access-user-flow.md`](https://learn.microsoft.com/en-us/azure/active-directory-b2c/conditional-access-user-flow) |
| Monitor phone-authentication failures via Azure Monitor workbook | [`phone-based-mfa.md` § Create a phone-based MFA events workbook](https://learn.microsoft.com/en-us/azure/active-directory-b2c/phone-based-mfa) |
| Neutral definition of the attack vector (term not currently used on learn.microsoft.com) | [Wikipedia — International Revenue Share Fraud](https://en.wikipedia.org/wiki/International_revenue_share_fraud) |
